### PR TITLE
Use the same private key to connect to bastion

### DIFF
--- a/aws-40/templates/extra_vars.yml.j2
+++ b/aws-40/templates/extra_vars.yml.j2
@@ -2,4 +2,5 @@
 openshift_test_repo: https://rpms.svc.ci.openshift.org/openshift-origin-v4.0/
 kubeconfig_path: {{ kubeconfig_path }}
 openshift_aws_scaleup_key_path: {{ private_key_path }}
+ansible_ssh_private_key_file: {{ private_key_path }}
 pull_secret: {{ pull_secret_path }}


### PR DESCRIPTION
Resolves issue where ssh to bastion is trying to use ~/.ssh/id_rsa.