### PR TITLE
libvirt-40: create-cluster without scaleup

### DIFF
--- a/libvirt-40/README.md
+++ b/libvirt-40/README.md
@@ -1,0 +1,37 @@
+# OpenShift Ansible Test Cluster Builder
+
+## Overview
+
+## Prerequisites
+
+* libvirt installed and configured per https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md
+* Pull secret saved as ~/pull-secret.txt from https://cloud.openshift.com/clusters/install, Step 4
+* OpenShift shared-secrets repo cloned parallel to this repo
+* ???
+
+## Add dns to libvirt
+
+Add the following lines to your libvirt dnsmasq:
+
+```bash
+echo server=/tt.testing/192.168.126.1 | sudo tee /etc/NetworkManager/dnsmasq.d/openshift.conf
+echo address=/.apps.tt.testing/192.168.126.51 | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
+sudo systemctl reload NetworkManager
+```
+
+## Building and scaling up a cluster
+
+Update options in build_options.sh as needed, then run:
+
+```bash
+$ ./build.sh
+```
+
+## Destroying a cluster
+
+When you are done with a cluster you can run a command to destroy the cluster
+and clean up logs.
+
+```bash
+$ ./destroy.sh
+```

--- a/libvirt-40/ansible.cfg
+++ b/libvirt-40/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+retry_files_enabled = False

--- a/libvirt-40/assets/.gitignore
+++ b/libvirt-40/assets/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/libvirt-40/bin/.gitignore
+++ b/libvirt-40/bin/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/libvirt-40/build.sh
+++ b/libvirt-40/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+./compile-installer.sh
+./create-cluster.sh
+#./clone-ansible.sh
+#./clone-openshift-ansible.sh
+#./node-scaleup40.sh

--- a/libvirt-40/build_options.sh
+++ b/libvirt-40/build_options.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+CURRENT_USER=$(id -un)
+export OPT_CLUSTER_ID=${CURRENT_USER}-${PWD##*-}
+export PYTHON=$(which python3)
+
+##################################################
+# Secrets
+##################################################
+export OPT_PULL_SECRET=~/pull-secret.txt   # https://cloud.openshift.com/clusters/install, Step 4
+export OPT_PRIVATE_KEY=${PWD}/../../shared-secrets/aws/libra.pem
+
+##################################################
+# Provision/Terminate
+##################################################
+export OPT_CLUSTER_DIR=${PWD}
+export OPT_MASTER_COUNT=0
+export OPT_COMPUTE_COUNT=1
+export OPT_INFRA_COUNT=0
+export OPT_PLATFORM_TYPE=centos        # rhel/centos
+export OPT_INSTANCE_TYPE=t2.medium
+#export OPT_INSTANCE_TYPE=c5.large
+export AWS_PROFILE="openshift-dev"
+export AWS_DEFAULT_REGION=us-east-2
+
+##################################################
+# Clone Ansible
+##################################################
+#export OPT_ANSIBLE_PRNUM=XXXXX
+export OPT_ANSIBLE_TAG=v2.7.8
+#export OPT_ANSIBLE_TAG=<commit_hash>
+
+##################################################
+# Clone OpenShift-Ansible
+##################################################
+#export OPT_OA_PRNUM=XXXXX
+export OPT_OA_TAG=devel-40

--- a/libvirt-40/clone-ansible.sh
+++ b/libvirt-40/clone-ansible.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+SCRIPT_TYPE=$(basename -s .sh "$0")
+LOG_DATE=$(date "+%FT%H.%M.%S")
+
+unbuffer ../scripts/clone-ansible.sh |& tee logs/${LOG_DATE}-${SCRIPT_TYPE}.log

--- a/libvirt-40/clone-openshift-ansible.sh
+++ b/libvirt-40/clone-openshift-ansible.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+SCRIPT_TYPE=$(basename -s .sh "$0")
+LOG_DATE=$(date "+%FT%H.%M.%S")
+
+unbuffer ../scripts/clone-openshift-ansible.sh |& tee  logs/${LOG_DATE}-${SCRIPT_TYPE}.log

--- a/libvirt-40/compile-installer.sh
+++ b/libvirt-40/compile-installer.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+SCRIPT_TYPE=$(basename -s .sh "$0")
+LOG_DATE=$(date "+%FT%H.%M.%S")
+
+export TAGS=libvirt
+unbuffer ../scripts/compile-installer.sh |& tee logs/${LOG_DATE}-${SCRIPT_TYPE}.log

--- a/libvirt-40/create-cluster.sh
+++ b/libvirt-40/create-cluster.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+source build_options.sh
+
+ansible-playbook -i localhost, create-install-assets.yml
+
+bin/openshift-install create manifests --dir=./assets --log-level=debug
+
+# Modify the apps domain so the cluster can perform lookups internally.
+sed -i "/  domain: apps.${OPT_CLUSTER_ID}.tt.testing/c\  domain: apps.tt.testing" assets/manifests/cluster-ingress-02-config.yml
+
+bin/openshift-install create cluster --dir=./assets --log-level=debug

--- a/libvirt-40/create-install-assets.yml
+++ b/libvirt-40/create-install-assets.yml
@@ -1,0 +1,36 @@
+---
+
+- name: Create OpenShift Install Assets
+  hosts: localhost
+  connection: local
+  gather_facts: no
+
+  vars:
+    aws_region: "{{ lookup('env', 'AWS_DEFAULT_REGION') }}"
+    cluster_id: "{{ lookup('env', 'OPT_CLUSTER_ID') }}"
+    pull_secret_path: "{{ lookup('env', 'OPT_PULL_SECRET') }}"
+    private_key_path: "{{ lookup('env', 'OPT_PRIVATE_KEY') }}"
+
+  tasks:
+  ## Create install-config.yaml
+  - name: Retrieve pull secret
+    slurp:
+      src: "{{ pull_secret_path }}"
+    register: pull_secret
+    no_log: true
+
+  - name: Ensure proper permissions on private key file
+    file:
+      path: "{{ private_key_path }}"
+      mode: 0600
+
+  - name: Create public key from private key file
+    command: >
+      ssh-keygen -f {{ private_key_path }} -y
+    register: keygen_output
+
+  - name: Create install-config.yaml
+    template:
+      src: install-config.yaml.j2
+      dest: assets/install-config.yaml
+  ## install-config.yaml

--- a/libvirt-40/destroy.sh
+++ b/libvirt-40/destroy.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+export AWS_PROFILE="openshift-dev"
+
+bin/openshift-install destroy cluster --dir=./assets --log-level=debug
+
+rm -f ./assets/.openshift_install*
+rm -f ./assets/metadata.json
+rm -f ./assets/terraform.tfstate
+rm -f ./assets/disable-bootstrap.tfvars
+
+rm -f extra_vars.yml
+
+rm -f logs/*.log

--- a/libvirt-40/logs/.gitignore
+++ b/libvirt-40/logs/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/libvirt-40/templates/extra_vars.yml.j2
+++ b/libvirt-40/templates/extra_vars.yml.j2
@@ -1,0 +1,6 @@
+---
+openshift_test_repo: https://rpms.svc.ci.openshift.org/openshift-origin-v4.0/
+kubeconfig_path: {{ kubeconfig_path }}
+openshift_aws_scaleup_key_path: {{ private_key_path }}
+ansible_ssh_private_key_file: {{ private_key_path }}
+pull_secret: {{ pull_secret_path }}

--- a/libvirt-40/templates/install-config.yaml.j2
+++ b/libvirt-40/templates/install-config.yaml.j2
@@ -1,0 +1,19 @@
+apiVersion: v1beta3
+baseDomain: tt.testing
+compute:
+- name: worker
+  replicas: 1
+controlPlane:
+  name: master
+  replicas: 1
+metadata:
+  name: {{ cluster_id }}
+networking:
+  machineCIDR: 192.168.126.0/24
+platform:
+  libvirt:
+    network:
+      if: tt0
+pullSecret: '{{ pull_secret['content'] | b64decode | from_json | to_json(separators=(',',':')) }}'
+sshKey: |
+  {{ keygen_output.stdout }}


### PR DESCRIPTION
This adds libvirt-40, the ability to provision 4.0 on libvirt similar to aws-40. It does not yet include scaleup as that will be added later. There is one hack used to get the route's dns entries working internally by editing assets/manifests/cluster-ingress-02-config.yml. This should probably be fixed in openshift-install and then deprecated here.