### PR TITLE
Add no-pager to git log cmd

### DIFF
--- a/scripts/clone-ansible.sh
+++ b/scripts/clone-ansible.sh
@@ -36,4 +36,4 @@ if [ -v OPT_ANSIBLE_TAG ]; then
 fi
 
 git describe
-git log --oneline -5
+git --no-pager log --oneline -5

--- a/scripts/clone-openshift-ansible.sh
+++ b/scripts/clone-openshift-ansible.sh
@@ -36,4 +36,4 @@ if [ -v OPT_OA_TAG ]; then
 fi
 
 git describe
-git log --oneline -5
+git --no-pager log --oneline -5

--- a/scripts/compile-installer.sh
+++ b/scripts/compile-installer.sh
@@ -9,7 +9,7 @@ git fetch --all --tags --prune
 # Checkout the latest tag
 git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
 git describe
-git log --oneline -5
+git --no-pager log --oneline -5
 
 hack/build.sh
 


### PR DESCRIPTION
Unable to quit the `git log` commands I think related to using tmux.
This PR disables the pager for git log.  There are other ways to fix this
if the pause is required.