### PR TITLE
Extract the installer binary from the release payload

### DIFF
--- a/aws-40/build.sh
+++ b/aws-40/build.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-./compile-installer.sh
+#./compile-installer.sh
+./extract-installer.sh
 ./create-cluster.sh
 ./clone-ansible.sh
 ./clone-openshift-ansible.sh

--- a/aws-40/build_options.sh
+++ b/aws-40/build_options.sh
@@ -18,6 +18,14 @@ export OPT_PLATFORM_TYPE=centos        # rhel/centos
 export AWS_PROFILE="openshift-dev"
 export AWS_DEFAULT_REGION=us-east-2
 
+#export OPT_REGISTRY=registry.svc.ci.openshift.org/ocp/release
+#export OPT_PAYLOAD=v4.0                # This points to the latest accepted nightly
+#export OPT_PAYLOAD=4.0.0-0.ci-YYYY-MM-DD-HHMMSS
+
+export OPT_REGISTRY=registry.svc.ci.openshift.org/openshift/origin-release
+export OPT_PAYLOAD=v4.0                # This points to the latest accepted alpha
+#export OPT_PAYLOAD=4.0.0-0.alpha-YYYY-MM-DD-HHMMSS
+
 ##################################################
 # Clone Ansible
 ##################################################

--- a/aws-40/destroy.sh
+++ b/aws-40/destroy.sh
@@ -9,7 +9,7 @@ rm -f ./assets/.openshift_install*
 rm -f ./assets/metadata.json
 rm -f ./assets/terraform.tfstate
 
-rm -f ./bin/openshift-install
+rm -fv bin/o* bin/sha*
 
 rm -f extra_vars.yml
 

--- a/aws-40/extract-installer.sh
+++ b/aws-40/extract-installer.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+source build_options.sh
+
+# Extract the installer binary from the release payload
+pushd bin
+rm -fv o* sha*
+oc adm release extract --tools ${OPT_REGISTRY}:${OPT_PAYLOAD} -a ${OPT_PULL_SECRET}
+for a in $(ls -1 *.tar.gz); do tar -zxvf $a; done
+popd


### PR DESCRIPTION
Stops compiling the installer from source and pulls the binary from the release payload.  Override is not necessary as the installer is pinned to the payload release.

A current version of `oc` is required to support the `--tools` option.