### PR TITLE
Add watchbootstrap.sh and watchcluster.sh

### DIFF
--- a/scripts/watchbootstrap.sh
+++ b/scripts/watchbootstrap.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+if [ -z $1 ]; then
+  TARGETDIR='assets'
+else
+  TARGETDIR=$1
+fi
+if [ -f build_options.sh ]; then
+  source build_options.sh
+fi
+while true; do
+  if [ -f ${TARGETDIR}/metadata.json ]; then
+    if [ "$(jq '.aws' ${TARGETDIR}/metadata.json)" != "null" ]; then
+      IP=$(jq '.resources[] | select(.module == "module.bootstrap") | select(.type == "aws_instance") | select(.name == "bootstrap") | .instances[0].attributes.public_ip' ${TARGETDIR}/terraform.tfstate | tr -d "\"")
+    fi;
+    if [ "$(jq '.gcp' ${TARGETDIR}/metadata.json)" != "null" ]; then
+      IP=$(jq '.resources[] | select(.module == "module.bootstrap") | select(.type == "google_compute_address") | select(.name == "bootstrap") | .instances[0].attributes.address' ${TARGETDIR}/terraform.tfstate | tr -d "\"")
+    fi;
+  else
+    echo "${TARGETDIR}/metadata.json not found"
+    IP=""
+  fi
+
+  if [ -n "${IP}" ];
+  then
+    ssh -i ${OPT_PRIVATE_KEY:-'~/.ssh/openshift-dev.pem'} \
+      -o ConnectTimeout=5 \
+      -o StrictHostKeyChecking=no \
+      -o PasswordAuthentication=no \
+      -o UserKnownHostsFile=/dev/null \
+      core@${IP} \
+      'journalctl -b -f -u bootkube.service'
+  fi
+  sleep 10
+done;

--- a/scripts/watchcluster.sh
+++ b/scripts/watchcluster.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+export KUBECONFIG=assets/auth/kubeconfig
+watch -n 5 '
+  oc get clusterversion --no-headers \
+  && oc get events -o json | jq -r ".items[] | select(.type != \"Normal\") | select(.reason != \"Rebooted\") | .lastTimestamp + \" \" + .type + \" \" + .reason + \": \" + .message" | tail -n 5
+  oc get nodes;
+  oc get csr --no-headers | grep "Pending";
+  oc get clusteroperator | grep -v "True        False         False";
+'


### PR DESCRIPTION
This change adds two shell scripts useful for watching a v4 cluster
while it is bootstrapping. The first, watchbootstrap.sh, will invoke an
indefiniate loop where it will automatically determine the IP address of
the bootstrap host based on the terraform state file and then ssh into
that host and display the journal logs for the bootkube service. The
second will use watch to continually display the output of multiple oc
commands: the cluster version and status, any unusual events, the list of
nodes, the list of pending csr requests, and existing cluster operators
that are not in the desired state.