### PR TITLE
Initial vSphere scale up terraform

### DIFF
--- a/playbooks/prep40.yml
+++ b/playbooks/prep40.yml
@@ -1,6 +1,6 @@
 ---
 - name: Prep Playbook
-  hosts: all
+  hosts: new_workers
   any_errors_fatal: true
   gather_facts: false
 

--- a/scripts/vsphere-scaleup.sh
+++ b/scripts/vsphere-scaleup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+source build_options.sh
+# shellcheck source=/dev/null
+source "${OPT_CLUSTER_DIR}/ansible/hacking/env-setup"
+
+
+time ${LOCAL_PYTHON} "$(command -v ansible-playbook)" -i "../terraform/vsphere/hosts.ini" ../playbooks/prep40.yml -vvv
+
+pushd "${OPT_CLUSTER_DIR}/openshift-ansible"
+# Use the extracted `oc` when running playbooks
+PATH=${OPT_CLUSTER_DIR}/bin:$PATH
+command -v oc
+
+time ${LOCAL_PYTHON} "$(command -v ansible-playbook)" -i "../../terraform/vsphere/hosts.ini" playbooks/scaleup.yml -vvv
+
+popd

--- a/terraform/vsphere/README.md
+++ b/terraform/vsphere/README.md
@@ -1,0 +1,71 @@
+### vSphere RHEL scale up
+
+### Gotchas
+- `ansible.cfg` in openshift-ansible might need to be modified: `control_path = /tmp/%%h-%%r`
+
+### Requirements
+
+- Same as vSphere UPI terraform
+- OCP cluster available on vSphere UPI
+- RHEL template (see below)
+
+#### RHEL template
+
+The RHEL template must have the following packages
+either added or removed
+```
+yum install open-vm-tools perl -y
+# if installed, cloud-init breaks vSphere guest customization
+yum erase cloud-init -y
+```
+
+### Running terraform
+
+#### Variables
+
+Copy your `terraform.tfvars` to this directory or change
+the `terraform apply` for the correct path to the `terraform.tfvars`
+
+This uses most of the exiting variables that vSphere UPI already does.
+In the `terraform.rhel.tfvars` modify per your template:
+
+```
+rhel_vm_template = "rhel77-template-test"
+```
+
+By default the terraform will create three (3) RHEL instances. To change
+this add:
+
+```
+rhel_compute_count = "#"
+```
+
+#### Terraform
+
+Running:
+
+```
+terraform init
+terraform apply -auto-approve -var-file terraform.tfvars -var-file terraform.rhel.tfvars
+
+
+#test after complete:
+ansible --private-key ~/.ssh/openshift-dev.pem -m setup -i hosts.ini new_workers
+```
+
+### Scale Up
+
+Within a `aws-4{a,b}` directory configure `build_options.sh`
+
+Then execute:
+```
+./test-cluster.sh clone-ansible
+./test-cluster.sh clone-openshift-ansible
+./test-cluster.sh extract-installer
+../scripts/vsphere-scaleup.sh
+```
+
+### TODO
+
+- add variables to set netmask and gateway or determine from ipam
+- add/modify scripts to integrate with existing scale up

--- a/terraform/vsphere/ansible.cfg
+++ b/terraform/vsphere/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+retry_files_enabled = False
+host_key_checking = False

--- a/terraform/vsphere/cluster_domain/main.tf
+++ b/terraform/vsphere/cluster_domain/main.tf
@@ -1,0 +1,27 @@
+locals {
+  lb_hostnames = ["api", "api-int", "*.apps"]
+}
+
+data "aws_route53_zone" "base" {
+  name = var.base_domain
+}
+
+resource "aws_route53_zone" "cluster" {
+  name          = var.cluster_domain
+  force_destroy = true
+
+  tags = {
+    "Name"     = var.cluster_domain
+    "Platform" = "vSphere"
+  }
+}
+
+resource "aws_route53_record" "name_server" {
+  name    = var.cluster_domain
+  type    = "NS"
+  ttl     = "300"
+  zone_id = data.aws_route53_zone.base.zone_id
+  records = aws_route53_zone.cluster.name_servers
+}
+
+

--- a/terraform/vsphere/cluster_domain/outputs.tf
+++ b/terraform/vsphere/cluster_domain/outputs.tf
@@ -1,0 +1,3 @@
+output "zone_id" {
+  value = aws_route53_zone.cluster.zone_id
+}

--- a/terraform/vsphere/cluster_domain/variables.tf
+++ b/terraform/vsphere/cluster_domain/variables.tf
@@ -1,0 +1,9 @@
+variable "cluster_domain" {
+  description = "The domain for the cluster that all DNS records must belong"
+  type        = string
+}
+
+variable "base_domain" {
+  description = "The base domain used for public records."
+  type        = string
+}

--- a/terraform/vsphere/hosts.tmpl
+++ b/terraform/vsphere/hosts.tmpl
@@ -1,0 +1,27 @@
+localhost ansible_connection=local
+[all:vars]
+# SSH user, this user should allow ssh based auth without requiring a
+# password. If using ssh key based auth, then the key should be managed by an
+# ssh agent.
+#ansible_user=cloud-user
+
+# If ansible_user is not root, ansible_become must be set to true and the
+# user must be configured for passwordless sudo
+#ansible_become=True
+
+###############################################################################
+# Required configuration variables                                            #
+###############################################################################
+
+# **NOTE** this variable will need to be changed
+openshift_kubeconfig_path="~/.kube/config"
+
+# probably should be moved
+ansible_ssh_private_key_file="~/.ssh/openshift-dev.pem"
+
+# For running RHEL worker scaleup
+[new_workers]
+%{ for h in hosts ~}
+${h} ansible_user=cloud-user ansible_become=yes
+%{ endfor ~}
+

--- a/terraform/vsphere/ipam/cidr_to_ip.sh
+++ b/terraform/vsphere/ipam/cidr_to_ip.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# cidr_to_ip -
+#  https://www.terraform.io/docs/providers/external/data_source.html
+#  Based on info from here: https://gist.github.com/irvingpop/968464132ded25a206ced835d50afa6b
+#  This script takes requests an IP address from an IPAM server
+#  echo '{"network": "139.178.89.192", "hostname": "control-plane-0.dphillip.devcluster.openshift.com", "ipam": "ipam_address", "ipam_token", "api_token" }' | ./cidr_to_ip.sh
+function error_exit() {
+  echo "$1" 1>&2
+  exit 1
+}
+
+function check_deps() {
+  test -f "$(command -v jq)" || error_exit "jq command not detected in path, please install it"
+
+}
+
+function parse_input() {
+  input=$(jq .)
+  network=$(echo "$input" | jq -r .network)
+  hostname=$(echo "$input" | jq -r .hostname)
+  ipam=$(echo "$input" | jq -r .ipam)
+  ipam_token=$(echo "$input" | jq -r .ipam_token)
+}
+
+is_ip_address() {
+  if [[ $1 =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]
+  then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+get_reservation() {
+  reservation=$(curl -s "http://${ipam}/api/getIPs.php?apiapp=address&apitoken=${ipam_token}&domain=${hostname}")
+  if [[ "${reservation}" == "[]" ]]; then echo ""
+  else
+    reserved_ip=$(echo "${reservation}" | jq -r ".\"${hostname}\"")
+    if [ "$(is_ip_address "${reserved_ip}")" == "false" ]; then echo ""
+    else echo "$reserved_ip"
+    fi
+  fi
+}
+
+function produce_output() {
+  if [[ "${network}" == "null" ]]
+  then
+    jq -n \
+      --arg ip_address "$(get_reservation)" \
+      '{"ip_address":$ip_address}'
+	exit 0
+  fi
+
+  timeout=$((SECONDS + 60))
+
+  # Request an IP address. Verify that the IP address reserved matches the IP
+  # address returned. Loop until the reservation matches the address returned.
+  # The verification and looping is a crude way of overcoming the lack of
+  # currency safety in the IPAM server.
+  while [[ $SECONDS -lt $timeout ]]
+  do
+    ip_address=$(curl -s "http://$ipam/api/getFreeIP.php?apiapp=address&apitoken=$ipam_token&subnet=${network}&host=${hostname}")
+
+    if [[ "$(is_ip_address "${ip_address}")" != "true" ]]; then error_exit "could not reserve an IP address: ${ip_address}"; fi
+
+    if [[ "$ip_address" == "$(get_reservation)" ]]
+	then
+      jq -n \
+        --arg ip_address "$ip_address" \
+        '{"ip_address":$ip_address}'
+      exit 0
+    fi
+
+    sleep 3
+  done
+
+  # IPAM server responds with 0.0.0.0 when there are no available addresses
+  if [[ "${ip_address}" =~ ^0 ]]
+  then
+    error_exit "could not reserve an IP address: no available addresses"
+  else
+    error_exit "could not reserve an IP address: timed out waiting for a reservation"
+  fi
+}
+
+# main()
+check_deps
+parse_input
+produce_output

--- a/terraform/vsphere/ipam/main.tf
+++ b/terraform/vsphere/ipam/main.tf
@@ -1,0 +1,53 @@
+locals {
+  network      = cidrhost(var.machine_cidr, 0)
+  ip_addresses = data.template_file.ip_address.*.rendered
+}
+
+data "external" "ip_address" {
+  count = var.instance_count
+
+  program = ["bash", "${path.module}/cidr_to_ip.sh"]
+
+  query = {
+    hostname   = "${var.name}-${count.index}.${var.cluster_domain}"
+    ipam       = var.ipam
+    ipam_token = var.ipam_token
+  }
+
+  depends_on = [null_resource.ip_address]
+}
+
+data "template_file" "ip_address" {
+  count = var.instance_count
+
+  template = data.external.ip_address[count.index].result["ip_address"]
+}
+
+resource "null_resource" "ip_address" {
+  count = var.instance_count
+
+  triggers = {
+    ipam           = var.ipam
+    name           = var.name
+    cluster_domain = var.cluster_domain
+    ipam_token     = var.ipam_token
+    network        = local.network
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+echo '{"network":"${self.triggers.network}","hostname":"${self.triggers.name}-${count.index}.${self.triggers.cluster_domain}","ipam":"${self.triggers.ipam}","ipam_token":"${self.triggers.ipam_token}"}' | ${path.module}/cidr_to_ip.sh
+EOF
+
+  }
+
+  provisioner "local-exec" {
+    when = destroy
+
+    command = <<EOF
+curl -s "http://${self.triggers.ipam}/api/removeHost.php?apiapp=address&apitoken=${self.triggers.ipam_token}&host=${self.triggers.name}-${count.index}.${self.triggers.cluster_domain}"
+EOF
+
+  }
+}
+

--- a/terraform/vsphere/ipam/outputs.tf
+++ b/terraform/vsphere/ipam/outputs.tf
@@ -1,0 +1,4 @@
+output "ip_addresses" {
+  value = flatten([local.ip_addresses])
+}
+

--- a/terraform/vsphere/ipam/variables.tf
+++ b/terraform/vsphere/ipam/variables.tf
@@ -1,0 +1,33 @@
+variable "name" {
+  type = string
+}
+
+variable "instance_count" {
+  type = string
+}
+
+variable "ignition" {
+  type    = string
+  default = ""
+}
+
+variable "cluster_domain" {
+  type = string
+}
+
+variable "machine_cidr" {
+  type = string
+}
+
+variable "ipam" {
+  type = string
+}
+
+variable "ipam_token" {
+  type = string
+}
+
+variable "ip_addresses" {
+  type = list(string)
+}
+

--- a/terraform/vsphere/ipam/versions.tf
+++ b/terraform/vsphere/ipam/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/vsphere/main.tf
+++ b/terraform/vsphere/main.tf
@@ -1,0 +1,137 @@
+provider "vsphere" {
+  user                 = var.vsphere_user
+  password             = var.vsphere_password
+  vsphere_server       = var.vsphere_server
+  allow_unverified_ssl = true
+}
+
+data "vsphere_datacenter" "dc" {
+  name = var.vsphere_datacenter
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = var.vsphere_datastore
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_network" "network" {
+  name          = var.vm_network
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_compute_cluster" "compute_cluster" {
+  name          = var.vsphere_cluster
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_virtual_machine" "template" {
+  name          = var.rhel_vm_template
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_resource_pool" "resource_pool" {
+  name          = var.cluster_id
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+// Request from phpIPAM a new IP addresses for the compute nodes
+module "ipam_rhel_compute" {
+  source         = "./ipam"
+  name           = "rhel-worker"
+  instance_count = var.rhel_compute_count
+  ipam           = var.ipam
+  ipam_token     = var.ipam_token
+  machine_cidr   = var.machine_cidr
+  ip_addresses   = []
+  cluster_domain = var.cluster_domain
+}
+
+
+// Uncomment this section if you
+// would like to create the subdomain
+/*
+module "dns_cluster_domain" {
+  source         = "./cluster_domain"
+  cluster_domain = var.cluster_domain
+  base_domain    = var.base_domain
+}
+*/
+
+
+// If the subdomain already exists
+// uncomment this section
+data "aws_route53_zone" "cluster" {
+  name = var.cluster_domain
+}
+
+resource "aws_route53_record" "a_record" {
+  count = length(module.ipam_rhel_compute.ip_addresses)
+
+  type    = "A"
+  ttl     = "60"
+
+  //if you would like to create the new subdomain
+  //uncomment this and above
+  //zone_id = module.dns_cluster_domain.zone_id
+
+  // This subdomain zone_id should already exist
+  // if you have already executed vSphere UPI
+  zone_id = data.aws_route53_zone.cluster.zone_id
+
+  name    = "rhel-worker-${count.index}.${var.cluster_domain}"
+  records = [module.ipam_rhel_compute.ip_addresses[count.index]]
+}
+
+resource "vsphere_virtual_machine" "vm" {
+  count = var.rhel_compute_count
+
+  name = element(split(".", aws_route53_record.a_record[count.index]["name"]), 0)
+
+  resource_pool_id = data.vsphere_resource_pool.resource_pool.id
+  datastore_id     = data.vsphere_datastore.datastore.id
+  num_cpus         = var.compute_num_cpus
+  memory           = var.compute_memory
+  guest_id         = data.vsphere_virtual_machine.template.guest_id
+  folder           = var.cluster_id
+  enable_disk_uuid = "true"
+
+  wait_for_guest_net_timeout  = "10"
+  wait_for_guest_net_routable = "true"
+
+  network_interface {
+    network_id = data.vsphere_network.network.id
+  }
+
+  disk {
+    label            = "disk0"
+    size             = 60
+    thin_provisioned = data.vsphere_virtual_machine.template.disks[0].thin_provisioned
+  }
+
+  clone {
+    template_uuid = data.vsphere_virtual_machine.template.id
+    customize {
+      linux_options {
+        host_name = element(split(".", aws_route53_record.a_record[count.index]["name"]), 0)
+        domain    = var.cluster_domain
+      }
+      network_interface {
+        ipv4_address = module.ipam_rhel_compute.ip_addresses[count.index]
+        # TODO: This needs to be a var
+        ipv4_netmask = 26
+        # TODO: This needs to be a var
+      }
+      ipv4_gateway    = "139.178.89.193"
+      dns_server_list = var.vm_dns_addresses
+    }
+  }
+}
+
+resource "local_file" "ansible_hosts_file" {
+  content = templatefile("${path.module}/hosts.tmpl", {
+    hosts = aws_route53_record.a_record.*.name
+  })
+
+  filename = "${path.module}/hosts.ini"
+}
+

--- a/terraform/vsphere/terraform.rhel.tfvars
+++ b/terraform/vsphere/terraform.rhel.tfvars
@@ -1,0 +1,1 @@
+rhel_vm_template = "rhel77-template-test"

--- a/terraform/vsphere/variables.tf
+++ b/terraform/vsphere/variables.tf
@@ -1,0 +1,175 @@
+// phpIPAM variables
+
+variable "ipam" {
+  type        = string
+  description = "The IPAM server to use for IP management."
+  default     = ""
+}
+
+variable "ipam_token" {
+  type        = string
+  description = "The IPAM token to use for requests."
+  default     = ""
+}
+
+//////
+// vSphere variables
+//////
+
+variable "vsphere_server" {
+  type        = string
+  description = "This is the vSphere server for the environment."
+}
+
+variable "vsphere_user" {
+  type        = string
+  description = "vSphere server user for the environment."
+}
+
+variable "vsphere_password" {
+  type        = string
+  description = "vSphere server password"
+}
+
+variable "vsphere_cluster" {
+  type        = string
+  description = "This is the name of the vSphere cluster."
+}
+
+variable "vsphere_datacenter" {
+  type        = string
+  description = "This is the name of the vSphere data center."
+}
+
+variable "vsphere_datastore" {
+  type        = string
+  description = "This is the name of the vSphere data store."
+}
+
+variable "vm_template" {
+  type        = string
+  description = "This is the name of the VM template to clone."
+}
+variable "rhel_vm_template" {
+  type        = string
+  description = "This is the name of the VM template to clone."
+}
+
+variable "vm_network" {
+  type        = string
+  description = "This is the name of the publicly accessible network for cluster ingress and access."
+  default     = "VM Network"
+}
+
+variable "vm_dns_addresses" {
+  type    = list(string)
+  default = ["1.1.1.1", "9.9.9.9"]
+}
+
+/////////
+// OpenShift cluster variables
+/////////
+
+variable "cluster_id" {
+  type        = string
+  description = "This cluster id must be of max length 27 and must have only alphanumeric or hyphen characters."
+}
+
+variable "base_domain" {
+  type        = string
+  description = "The base DNS zone to add the sub zone to."
+}
+
+variable "cluster_domain" {
+  type        = string
+  description = "The base DNS zone to add the sub zone to."
+}
+
+variable "machine_cidr" {
+  type = string
+}
+
+/////////
+// Bootstrap machine variables
+/////////
+
+variable "bootstrap_ignition_path" {
+  type    = string
+  default = "./bootstrap.ign"
+}
+
+variable "bootstrap_complete" {
+  type    = string
+  default = "false"
+}
+
+variable "bootstrap_ip_address" {
+  type    = list(string)
+  default = []
+}
+
+///////////
+// control-plane machine variables
+///////////
+
+variable "control_plane_ignition_path" {
+  type    = string
+  default = "./master.ign"
+}
+
+variable "control_plane_count" {
+  type    = string
+  default = "3"
+}
+
+variable "control_plane_ip_addresses" {
+  type    = list(string)
+  default = []
+}
+variable "control_plane_memory" {
+  type    = string
+  default = "16384"
+}
+
+variable "control_plane_num_cpus" {
+  type    = string
+  default = "4"
+}
+
+//////////
+// compute machine variables
+//////////
+
+variable "compute_ignition_path" {
+  type    = string
+  default = "./worker.ign"
+}
+
+variable "compute_count" {
+  type    = string
+  default = "3"
+}
+variable "rhel_compute_count" {
+  type    = string
+  default = "3"
+}
+
+variable "compute_ip_addresses" {
+  type    = list(string)
+  default = []
+}
+
+variable "compute_memory" {
+  type    = string
+  default = "8192"
+}
+
+variable "compute_num_cpus" {
+  type    = string
+  default = "4"
+}
+
+variable "ssh_public_key_path" {
+  type    = string
+  default = "~/.ssh/id_rsa.pub"
+}


### PR DESCRIPTION
This PR adds terraform that will use existing
`terraform.tfvars` plus a single additional variable
to provision ip addresses from ipam, A records from Route53
and clone RHEL virtual machines in vSphere.

The terraform has been tested.  Might need to modified based
on if vSphere UPI terraform has not been executed.  See `main.tf`
for additional details.