### PR TITLE
provision-vpc.sh to force output to json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ansible/
 *.log
 aws.json
+aws_vpc.json
 hosts
 openshift-ansible/
 test/

--- a/scripts/provision-vpc.sh
+++ b/scripts/provision-vpc.sh
@@ -11,6 +11,6 @@ then
 
   aws cloudformation wait stack-create-complete --stack-name "${OPT_CLUSTER_ID}"
 
-  aws cloudformation describe-stacks --stack-name "${OPT_CLUSTER_ID}" > inventory/aws_vpc.json
+  aws cloudformation describe-stacks --stack-name "${OPT_CLUSTER_ID}" --output json > inventory/aws_vpc.json
 fi
 


### PR DESCRIPTION
Previously, if ~/.aws/config was configured to default to output: text, then the aws_vpc.json file was not in json format. This forces the output to json so the provision step can work as expected. Also add the aws_vpc.json file to .gitignore.